### PR TITLE
[wip] Enable EngineView for FxA auth flow

### DIFF
--- a/samples/firefox-accounts/build.gradle
+++ b/samples/firefox-accounts/build.gradle
@@ -44,6 +44,14 @@ android {
 
 
 dependencies {
+    implementation project(':browser-engine-system')
+
+    implementation project(':browser-engine-gecko')
+    armImplementation "org.mozilla:geckoview-release-armeabi-v7a:${rootProject.ext.geckoRelease['version']}"
+    x86Implementation "org.mozilla:geckoview-release-x86:${rootProject.ext.geckoRelease['version']}"
+    aarch64Implementation "org.mozilla:geckoview-release-arm64-v8a:${rootProject.ext.geckoRelease['version']}"
+
+    implementation project(':concept-engine')
     implementation project(':service-firefox-accounts')   
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -27,8 +27,12 @@ import org.mozilla.geckoview.GeckoRuntime
 
 open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener, EngineViewLoginFragment.OnLoginCompleteListener {
 
+    private val systemEngine = SystemEngine()
+    private val geckoEngine = GeckoEngine(GeckoRuntime.create(applicationContext))
+
     private var account: FirefoxAccount? = null
     private var scopes: Array<String> = arrayOf("profile")
+    private val engine = systemEngine
 
     companion object {
         const val CLIENT_ID = "12cc4070a481bc73"
@@ -79,8 +83,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
     }
     override fun onCreateView(parent: View?, name: String?, context: Context, attrs: AttributeSet?): View? =
             when (name) {
-//                EngineView::class.java.name -> GeckoEngine(GeckoRuntime.getDefault(applicationContext)).createView(context, attrs).asView()
-                EngineView::class.java.name -> SystemEngine().createView(context, attrs).asView()
+                EngineView::class.java.name -> engine.createView(context, attrs).asView()
                 else -> super.onCreateView(parent, name, context, attrs)
             }
     override fun onDestroy() {

--- a/samples/firefox-accounts/src/main/res/layout/activity_main.xml
+++ b/samples/firefox-accounts/src/main/res/layout/activity_main.xml
@@ -33,6 +33,12 @@
             android:text="@string/sign_in_webview" />
 
         <Button
+            android:id="@+id/buttonEngineView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/sign_in_engineview" />
+
+        <Button
             android:id="@+id/buttonLogout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -45,6 +51,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:text="@string/log_out"/>
+        android:text="@string/logged_out"/>
 
 </RelativeLayout>

--- a/samples/firefox-accounts/src/main/res/layout/fragment_engine_view_login.xml
+++ b/samples/firefox-accounts/src/main/res/layout/fragment_engine_view_login.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".EngineViewLoginFragment">
+
+    <mozilla.components.concept.engine.EngineView
+        android:id="@+id/engineView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/samples/firefox-accounts/src/main/res/values/strings.xml
+++ b/samples/firefox-accounts/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
@@ -9,4 +8,5 @@
     <string name="signed_in">Signed in: %1$s</string>
     <string name="log_out">FxA Log Out</string>
     <string name="logged_out">Logged out!</string>
+    <string name="sign_in_engineview">FxA sign in: EngineView</string>
 </resources>


### PR DESCRIPTION
Waiting on a patch to the Gecko/SystemEngineView methods that will allow external members to set the `<WebView>.settings.javascriptEnabled` flags, but PR'ed in a personal fork so I don't forget about it